### PR TITLE
Escaping a couple variables before output in image.php template

### DIFF
--- a/theme/image.php
+++ b/theme/image.php
@@ -29,8 +29,8 @@ get_header();
 									esc_attr( get_the_date( 'c' ) ),
 									esc_html( get_the_date() ),
 									esc_url( wp_get_attachment_url() ),
-									$metadata['width'],
-									$metadata['height'],
+									esc_html( $metadata['width'] ),
+									esc_html( $metadata['height'] ),
 									esc_url( get_permalink( $post->post_parent ) ),
 									esc_attr( strip_tags( get_the_title( $post->post_parent ) ) ),
 									get_the_title( $post->post_parent )


### PR DESCRIPTION
Escapes width and height before substituting into image.php entry-meta string